### PR TITLE
Corrections for the "Gas optimizations" page

### DIFF
--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -56,10 +56,11 @@ addr.call(abi.encodeWithSelector(IERC20.transfer.selector, 0xSomeAddress, 123));
 - Use Events to store per user actions or UI related data. Using storage is costly and creates unnecessary getters and overhead
 - With events, something like TheGraph can be used to query them in an even powerful way than just storage view queries.
 
-## **Use External functions when possible** : 
+## **Use External functions when using old compiler versions**:
 
-- External function's parameters can be declared `calldata` and will be fetched from `calldata` itself when referenced.
-- For other types like `internal` and `public`, the parameters will be copied to memory by default which increases gas cost.
+- External function's parameters can be declared `calldata`, which means that they will not be decoded into memory unless absolutely necessary.
+    Decoding involves copying the whole value and increases gas cost.
+- For other types like `internal` and `public`, it was not possible to use `calldata` parameters before Solidity 0.6.9, so when using older compiler versions you have to make your function as `external` to be able to take advantage of this optimization.
 
 ## **Revert strings** :
 

--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -99,7 +99,7 @@ addr.call(abi.encodeWithSelector(IERC20.transfer.selector, 0xSomeAddress, 123));
 ## **bytes vs byte1[]**:
 
 - Again, check **internals** section for a detailed explanation.
-- TL;DR ? `bytes` has packing, `byte1[]` lacks packing in storage.
+- TL;DR ? `bytes` has packing, `byte1[]` lacks packing.
 
 ## **Limit external calls:**
 

--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -61,10 +61,13 @@ addr.call(abi.encodeWithSelector(IERC20.transfer.selector, 0xSomeAddress, 123));
 - External function's parameters can be declared `calldata` and will be fetched from `calldata` itself when referenced.
 - For other types like `internal` and `public`, the parameters will be copied to memory by default which increases gas cost.
 
-## **Require strings** :
+## **Revert strings** :
 
-- Long require strings too increase gas cost. Use smaller strings.
-- If you need large strings for some huge application, you can use some error codes as require strings and then maybe decode them on UI side, bypassing long string gas cost.
+- Long strings in `require()` or `revert()` too increase gas cost. Use [custom errors](https://docs.soliditylang.org/en/latest/contracts.html#errors-and-the-revert-statement) instead.
+- If you need large strings for some huge application, you can construct them on the UI side from the error type. You can also include additional parameters in the error, allowing your UI to insert them into the final message.
+- For maximum savings you can set `debug.revertStrings` setting to `"strip"`, which will strip **all** revert strings from your code.
+    Note, however, that this will make the failures of your contract very cryptic to users so it's not recommended.
+    In fact, it's a good idea to have this set to `"debug"` in non-production builds of your contract because the default value strips messages from reverts generated automatically by the compiler making them hard to debug.
 
 ## Don't repeat yourself : 
 

--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -104,6 +104,8 @@ addr.call(abi.encodeWithSelector(IERC20.transfer.selector, 0xSomeAddress, 123));
 ## **Limit external calls:**
 
 - This might be or not be possible. But try to decrease them as much as possible.
+    - Note that the alternative - internal calls - increases your bytecode size because the whole function gets compiled into your own contract.
+        If you care more about deployment cost or are hitting the contract size limit, an external call might be the right choice after all.
 - Every `external` call costs more gas than a simple internal call.
 
 ## **Make your contract upgradeable** : 

--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -96,10 +96,10 @@ addr.call(abi.encodeWithSelector(IERC20.transfer.selector, 0xSomeAddress, 123));
 - Because EVM store is a key value mapped store, mappings are cheaper for EVM than arrays
 - Check **internals** section for more details.
 
-## **Bytes32 vs byte1[]** : 
+## **bytes vs byte1[]**:
 
 - Again, check **internals** section for a detailed explanation.
-- TL;DR ? `bytes32` has packing, `byte1[]` lacks packing in storage.
+- TL;DR ? `bytes` has packing, `byte1[]` lacks packing in storage.
 
 ## **Limit external calls:**
 

--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -8,7 +8,7 @@ title : Solidity Gas Optimisations
 
 ## Read/Write costs : 
 
-Becuase solidity operates in 32 bytes at once, read/write to an element less than 32 bytes **costs more** as **EVM needs to do extra OPs retrieve and pad extra bytes to the element in that 32 byte slot**.
+Because solidity operates in 32 bytes at once, read/write to an element less than 32 bytes **costs more** as **EVM needs to do extra OPs retrieve and pad extra bytes to the element in that 32 byte slot**.
 
 So, operations with **32 bytes** costs less as no extra operations are involved. So **it is beneficial** to use reduced size elements like `uint8` **if you read them all at once, like a whole 32 byte slots at once as there isn't any padding operation involved **. So reading 4 `uint64` which are declared contiguosly is better **as there aren't any discard operations involved.** 
 
@@ -60,9 +60,9 @@ And use `addr.call(getSelector(funcName), 0xSomeAddress, 123))`. This saves a ti
 - Let `g(x)` be low cost and `h(x)` be high cost. Doing this saves some gas,
   - `g(x) && h(x)` as if `g(x)` fails, `h(x)` is never executed.
 
-## **Mappings are cheper than arrays** : 
+## **Mappings are cheaper than arrays**:
 
-- Becuase EVM store is a key value mapped store, mappings are cheaper for EVM than arrays
+- Because EVM store is a key value mapped store, mappings are cheaper for EVM than arrays
 - Check **internals** section for more details.
 
 ## **Bytes32 vs byte1[]** : 

--- a/Gas Optimisations.md
+++ b/Gas Optimisations.md
@@ -79,6 +79,17 @@ addr.call(abi.encodeWithSelector(IERC20.transfer.selector, 0xSomeAddress, 123));
 - Imagine you have to check 2 conditions one after other to pass the check. You should check the lower cost/less complex check first instead of high cost check.
 - Let `g(x)` be low cost and `h(x)` be high cost. Doing this saves some gas,
   - `g(x) && h(x)` as if `g(x)` fails, `h(x)` is never executed.
+- Note that `require()` **does not** short-circuit, which matters if your message is not a constant and is calculated at runtime instead.
+    This:
+    ```solidity
+    if (condition)
+        revert(getMessage());
+    ```
+    is more efficient than:
+    ```solidity
+    require(condition, getMessage());
+    ```
+    because it will not run `getMessage()` when the `condition` is false.
 
 ## **Mappings are cheaper than arrays**:
 


### PR DESCRIPTION
I noticed some errors, outdated information and things that can be done better in modern Solidity on the page about gas optimizations. I thought that instead complaining I could just correct them so here's a PR :)

I'll add comments below for cases that require more explanation but overall please see commit messages for reason behind each change.