### PR TITLE
Updated to 0.8.12, source : solidity blog, docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@
   - **Internals** : This document deals with explaining the data locations and how they can affect any gas costs. Organisation of data is also explained.
   - **Security** : This document deals with a few security vulnerabilities involved when writing smart contracts. In the end, it also has a few points on developing smart contracts. 
   - **Gas Optimisations :** This document mentions some things a smart contract developer can do to save gas costs. Security and Gas Optimsations by no means cover all exisiting topics, but they cover a few that are important.
-- This resource is written for **Solidity v0.8.11**.
+- This resource is updated for **Solidity v0.8.12**.
 
 ### Where
 
@@ -75,4 +75,3 @@
   has waived all copyright and related or neighboring rights to
   <span property="dct:title">Solidity Notes</span>.
 </p>
-


### PR DESCRIPTION
Updated the resource to version `0.8.12`

Changes : 

- Added missing `function pointers` type
- Added 0.8.12 support for equality checks of function pointers
- Added 0.8.12 support for `ContractName.functionName` inside `abi.encodeCall`

Corrections : 
- Uninitialised storage pointers do not have the same behaviour in recent versions. Left a note.

Source : 
- [Solidity Blog](https://blog.soliditylang.org/2022/02/16/solidity-0.8.12-release-announcement/)
- The Official Solidity Documentation